### PR TITLE
Add TagPrefix configuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,6 +10,7 @@ const (
 	DefaultMaxTrialForConnection = 10
 	DefaultConnectionTimeout     = 3 * time.Second
 	DefaultBufferingTimeout      = 100 * time.Millisecond
+	DefaultTagPrefix             = ""
 )
 
 var (
@@ -38,6 +39,10 @@ type Config struct {
 
 	// Logger flushes its buffer on each BufferingTimeout interval.
 	BufferingTimeout time.Duration
+
+	// Tag prefix. When set TagPrefix to "foo" and post with "bar.baz",
+	// you'll get "foo.bar.baz" tag.
+	TagPrefix string
 }
 
 func (c *Config) applyDefaultValues() {
@@ -48,6 +53,7 @@ func (c *Config) applyDefaultValues() {
 	assignIfDefault(&c.MaxTrialForConnection, DefaultMaxTrialForConnection)
 	assignIfDefault(&c.ConnectionTimeout, DefaultConnectionTimeout)
 	assignIfDefault(&c.BufferingTimeout, DefaultBufferingTimeout)
+	assignIfDefault(&c.TagPrefix, DefaultTagPrefix)
 }
 
 func assignIfDefault(target interface{}, DefaultValue interface{}) {

--- a/config_test.go
+++ b/config_test.go
@@ -15,6 +15,7 @@ func TestApplyDefaultValues(t *testing.T) {
 	assertEqual(t, config.MaxTrialForConnection, intDefault)
 	assertEqual(t, config.ConnectionTimeout, durationDefault)
 	assertEqual(t, config.BufferingTimeout, durationDefault)
+	assertEqual(t, config.TagPrefix, stringDefault)
 
 	config.applyDefaultValues()
 	assertEqual(t, config.FluentHost, DefaultFluentHost)
@@ -24,6 +25,7 @@ func TestApplyDefaultValues(t *testing.T) {
 	assertEqual(t, config.MaxTrialForConnection, DefaultMaxTrialForConnection)
 	assertEqual(t, config.ConnectionTimeout, DefaultConnectionTimeout)
 	assertEqual(t, config.BufferingTimeout, DefaultBufferingTimeout)
+	assertEqual(t, config.TagPrefix, DefaultTagPrefix)
 
 	config = Config{
 		FluentHost:            "localhost",
@@ -33,6 +35,7 @@ func TestApplyDefaultValues(t *testing.T) {
 		MaxTrialForConnection: 3,
 		ConnectionTimeout:     2 * time.Second,
 		BufferingTimeout:      2 * time.Second,
+		TagPrefix:             "prefix",
 	}
 
 	config.applyDefaultValues()
@@ -43,6 +46,7 @@ func TestApplyDefaultValues(t *testing.T) {
 	assertEqual(t, config.MaxTrialForConnection, 3)
 	assertEqual(t, config.ConnectionTimeout, 2*time.Second)
 	assertEqual(t, config.BufferingTimeout, 2*time.Second)
+	assertEqual(t, config.TagPrefix, "prefix")
 }
 
 func assertEqual(t *testing.T, actual interface{}, expect interface{}) {

--- a/logger.go
+++ b/logger.go
@@ -36,6 +36,9 @@ func NewLogger(config Config) *Logger {
 
 // You can send message to logger's goroutine via channel.
 func (l *Logger) Post(tag string, data interface{}) {
+	if l.config.TagPrefix != "" {
+		tag = l.config.TagPrefix + "." + tag
+	}
 	l.postCh <- message{tag: tag, time: time.Now(), data: data}
 }
 


### PR DESCRIPTION
TagPrefix configuration is commin within fluent-logger libraries.
- https://github.com/fluent/fluent-logger-ruby#tag-prefix
- https://github.com/fluent/fluent-logger-java/blob/master/src/main/java/org/fluentd/logger/FluentLogger.java
