### PR TITLE
Revert "Allocate logging buffer first"

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -26,7 +26,6 @@ func NewLogger(config Config) *Logger {
 	logger := &Logger{
 		config:   config,
 		postCh:   make(chan message, config.ChannelLength),
-		buffer:   make([]byte, config.BufferLength),
 		ticker:   time.NewTicker(config.BufferingTimeout),
 		logError: true,
 	}


### PR DESCRIPTION
This reverts commit 35e5b0ff018d2d3f9ce31b434de9076933fb55f6.

```go
buffer := make([]byte, 3)
buffer = append(buffer, 41)
// buffer == [0 0 0 41]
```