### PR TITLE
Allocate buffer capacity first

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -26,6 +26,7 @@ func NewLogger(config Config) *Logger {
 	logger := &Logger{
 		config:   config,
 		postCh:   make(chan message, config.ChannelLength),
+		buffer:   make([]byte, 0, config.BufferLength),
 		ticker:   time.NewTicker(config.BufferingTimeout),
 		logError: true,
 	}


### PR DESCRIPTION
Retry of 35e5b0ff018d2d3f9ce31b434de9076933fb55f6
Related to #3

``` go
gore> buffer := make([]byte, 3)
[]uint8{
  0x00, 0x00, 0x00,
}
gore> len(buffer)
3
gore> cap(buffer)
3
gore> buffer := make([]byte, 0, 3)
[]uint8{}
gore> len(buffer)
0
gore> cap(buffer)
3
```
